### PR TITLE
fix: 修复Edge UA变更导致的browser和version识别异常问题

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -338,7 +338,7 @@ const Device = (function () {
           'Safari': u?.indexOf('Safari') > -1,
           'Chrome': u?.indexOf('Chrome') > -1 || u?.indexOf('CriOS') > -1,
           'IE': u?.indexOf('MSIE') > -1 || u?.indexOf('Trident') > -1,
-          'Edge': u?.indexOf('Edge') > -1,
+          'Edge': u?.indexOf('Edg') > -1,
           'Firefox': u?.indexOf('Firefox') > -1 || u?.indexOf('FxiOS') > -1,
           'Firefox Focus': u?.indexOf('Focus') > -1,
           'Chromium': u?.indexOf('Chromium') > -1,
@@ -635,7 +635,7 @@ const Device = (function () {
             return u?.replace(/^.*MSIE ([\d.]+).*$/, '$1')?.replace(/^.*rv:([\d.]+).*$/, '$1')
           },
           'Edge': function () {
-            return u?.replace(/^.*Edge\/([\d.]+).*$/, '$1')
+            return u?.replace(/^.*Edge?\/([\d.]+).*$/, '$1')
           },
           'Firefox': function () {
             return u?.replace(/^.*Firefox\/([\d.]+).*$/, '$1')?.replace(/^.*FxiOS\/([\d.]+).*$/, '$1')


### PR DESCRIPTION
新版Edge UA 关键字为Edg，更新适配规则
UA示例：
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0